### PR TITLE
Mention the correct package in docs example

### DIFF
--- a/docs/src/components/Syntax.jsx
+++ b/docs/src/components/Syntax.jsx
@@ -14,7 +14,7 @@ require('codemirror/theme/neat.css');
 require('codemirror/mode/xml/xml.js');
 require('codemirror/mode/javascript/javascript.js');
 
-import 'Codemirror' from 'react-codemirror';
+import 'Codemirror' from 'react-codemirror2';
 
 <CodeMirror
   value={this.value}


### PR DESCRIPTION
Unless I'm missing something, the example should say `react-codemirror2`, no?