### PR TITLE
Include codemirror in npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 demo @ [scniro.github.io/react-codemirror2](https://scniro.github.io/react-codemirror2/)
 
-> npm install react-codemirror2
+> npm install react-codemirror2 codemirror
 
 ## basic usage
 ```jsx


### PR DESCRIPTION
For new folks, it's not super obvious you need to install codemirror as a peer dep. This will make folks who are copy/pasting have less issues. 