### PR TITLE
Use `window.CodeMirror` if present to construct editor instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ var React = require('react');
 var SERVER_RENDERED = (typeof navigator === 'undefined' || global['PREVENT_CODEMIRROR_RENDER'] === true);
 var cm;
 if (!SERVER_RENDERED) {
-    cm = require('codemirror');
+    if (window && window.CodeMirror) {
+        cm = window.CodeMirror;
+    }
+    else {
+        cm = require('codemirror');
+    }
 }
 var Helper = (function () {
     function Helper() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-codemirror2",
-  "version": "4.0.0",
+  "version": "4.1.0-beta.0",
   "description": "a tiny react codemirror component wrapper",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,11 @@ const SERVER_RENDERED = (typeof navigator === 'undefined' || global['PREVENT_COD
 
 let cm;
 if (!SERVER_RENDERED) {
-  cm = require('codemirror');
+  if (window && (window as any).CodeMirror) {
+    cm = (window as any).CodeMirror;
+  } else {
+    cm = require('codemirror');
+  }
 }
 
 export interface IDefineModeOptions {


### PR DESCRIPTION
I wanted to use CodeMirror's HTML linting capabilities with an editor instance created by react-codemirror2. I ended up taking the approach of configuring CodeMirror and assigning to `window.CodeMirror` _before importing react-codemirror2_.

The change in this PR has react-codemirror2 use `window.codeMirror`, if present, rather than importing `codemirror` on its own. This means we can now **use CodeMirror addons** via the configuration approach described above.

Note: I'm sure this could be accomplished by using a prop as well; unfortunately I'm not very familiar with TypeScript at this point, so this seemed like a more involved change than I was prepared to make today.

Thanks and I'll do my best to answer any questions!