### PR TITLE
Adds options to constructor, fixes #100

### DIFF
--- a/.ts/index.js
+++ b/.ts/index.js
@@ -363,10 +363,10 @@ var Controlled = (function (_super) {
                 cm.defineMode(this.props.defineMode.name, this.props.defineMode.fn);
             }
         }
-        this.editor = cm(this.ref);
+        this.editor = cm(this.ref, this.props.options);
         this.shared = new Shared(this.editor, this.props);
         this.mirror = cm(function () {
-        });
+        }, this.props.options);
         this.editor.on('electricInput', function () {
             _this.mirror.setHistory(_this.editor.getDoc().getHistory());
         });
@@ -495,7 +495,7 @@ var UnControlled = (function (_super) {
                 cm.defineMode(this.props.defineMode.name, this.props.defineMode.fn);
             }
         }
-        this.editor = cm(this.ref);
+        this.editor = cm(this.ref, this.props.options);
         this.shared = new Shared(this.editor, this.props);
         this.editor.on('beforeChange', function (cm, data) {
             if (_this.props.onBeforeChange) {

--- a/index.js
+++ b/index.js
@@ -485,9 +485,9 @@ var Controlled = function(_super) {
       }
     }
 
-    this.editor = cm(this.ref);
+    this.editor = cm(this.ref, this.props.options);
     this.shared = new Shared(this.editor, this.props);
-    this.mirror = cm(function() {});
+    this.mirror = cm(function() {}, this.props.options);
     this.editor.on('electricInput', function() {
       _this.mirror.setHistory(_this.editor.getDoc().getHistory());
     });
@@ -662,7 +662,7 @@ var UnControlled = function(_super) {
       }
     }
 
-    this.editor = cm(this.ref);
+    this.editor = cm(this.ref, this.props.options);
     this.shared = new Shared(this.editor, this.props);
     this.editor.on('beforeChange', function(cm, data) {
       if (_this.props.onBeforeChange) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-codemirror2",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "a tiny react codemirror component wrapper",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -510,12 +510,12 @@ export class Controlled extends React.Component<IControlledCodeMirror, any> {
       }
     }
 
-    this.editor = cm(this.ref) as codemirror.Editor;
+    this.editor = cm(this.ref, this.props.options) as codemirror.Editor;
 
     this.shared = new Shared(this.editor, this.props);
 
     this.mirror = (cm as any)(() => {
-    });
+    }, this.props.options);
 
     this.editor.on('electricInput', () => {
       this.mirror.setHistory(this.editor.getDoc().getHistory());
@@ -713,7 +713,7 @@ export class UnControlled extends React.Component<IUnControlledCodeMirror, any> 
       }
     }
 
-    this.editor = cm(this.ref) as codemirror.Editor;
+    this.editor = cm(this.ref, this.props.options) as codemirror.Editor;
 
     this.shared = new Shared(this.editor, this.props);
 

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -59,6 +59,29 @@ describe('[Controlled, UnControlled]: init', () => {
     expect(cUnmounted).toBeTruthy();
   });
 
+  // refs https://github.com/scniro/react-codemirror2/issues/100
+  // prior to 7115754851dde1e1ae90be9f1c1a5e46faecc016 would throw
+  it('should allow inputStyle to be set (uses the constructor)', () => {
+    let inputStyle = 'contenteditable' as const;
+    const options = {inputStyle};
+    Enzyme.shallow(
+      <UnControlled
+        options={options}
+        editorDidMount={(editor, value, next) => {
+          expect(editor.getInputField().tagName).toBe('DIV');
+        }}
+      />);
+    Enzyme.shallow(
+      <Controlled
+        value=""
+        options={options}
+        onBeforeChange={sinon.spy}
+        editorDidMount={(editor, value, next) => {
+          expect(editor.getInputField().tagName).toBe('DIV');
+        }}
+      />);
+  });
+
   it('should append a class name', () => {
 
     const uWrapper = Enzyme.mount(


### PR DESCRIPTION
Previously it was impossible to set `inputStyle` to `textarea` on a mobile device for instance. Now when hydrate runs it will not encounter a conflict with the initial/default setting.