### PR TITLE
Better callout for the install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@
 
 demo @ [scniro.github.io/react-codemirror2](https://scniro.github.io/react-codemirror2/)
 
-> npm install react-codemirror2 codemirror --save
+
+## Install
+
+```bash
+npm install react-codemirror2 codemirror --save
+```
 
 `react-codemirror2` ships with the notion of an [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) and [controlled](https://reactjs.org/docs/forms.html#controlled-components) component. `UnControlled` consists of a simple wrapper largely powered by the inner workings of `codemirror` itself, while `Controlled` will demand state management from the user, preventing codemirror changes unless properly handled via `value`. The latter will offer more control and likely be more appropriate with [redux](http://redux.js.org/) heavy apps.
 


### PR DESCRIPTION
The blockqoute was previously making the installation part appear to be missing. This PR improves visibility as seen below:

![image](https://user-images.githubusercontent.com/3419661/84716608-d8deea00-af30-11ea-8103-47db12e0ec97.png)
