### PR TITLE
Update README on how to test beautified JSON and RTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,32 @@ render() {
 
 Check out [bokuweb/re-resizable](https://github.com/bokuweb/re-resizable). Wrapping your component with `<Resizable/>'s` works well
 
+- Testing with [React Testing Library](https://testing-library.com/) (RTL)
+
+One issue when rendering react-codemirror2 with RTL is that if you pass in a string with line breaks (`\n`), like beautified JSON,
+it will only render the closing curly bracket `}`. This is due to how codemirror decides on what to show/hide
+in the editor with [jsdom](https://github.com/jsdom/jsdom/issues/135).
+Without the stub, codemirror will not render the entire string when testing with RTL.
+
+```jsx
+it('will render JSON beautified with react-testing-library', () => {
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetWidth: {
+      get() { return parseFloat(this.style.width) || 1 },
+    }
+  });
+
+  render(<UnControlled
+    options={{
+      mode: 'application/json',
+    }}
+    value={JSON.stringify({"react-testing-library": "works with react-codemirror2"}, null, 2)}
+  />);
+
+  expect(screen.getByText(/"react-testing-library": "works with react-codemirror2"/)).toBeVisible();
+});
+```
+
 ## Contributing
 
 Pull Requests are welcome. Be mindful of the available scripts below to help submitting a well-received contribution.


### PR DESCRIPTION
Adding a snippet to the README on how to test beautified JSON with `react-codemirror2` and `react-testing-library`.  My initial thought was to add an RTL test to verify it works but didn't want to have another test suite along with Enzyme.

When using beautified JSON with line breaks like in the README snippet, it'll render like [this with RTL and no stub](https://testing-playground.com/#markup=DwEwlgbgfKkAQGMA2BDAzmgvAIgE4FMUEAXAWgQHsR8BbMXXC3AJmxnAkVQxwGEr8AWXqNciGqTSlqAMxQBXJMWxxiuFADs0qYvhwaKbWJzTEAnkj3YKEfLhlIKAdwBccABZgQ1DQG44AA4UaGDEYBQabgQ6kPj+Tl7E7m4AzAEAHv7u+GAA5u7EbgAMGf7EFAHFpXCWMoVwJZlGuunEKAQocKYWVkEhYRFuKABGaBRI8rr+wxTE5TRupACMtP4BKN5gGrlVmXAJIEluS0Wn1dl5BcercHQapBf59Ss0-hSTSFv4bgYacSoKcqUBj4Eg4CgyGQAyYUBAoAKhFCfABeVghUK6AXwSCQCGyCAA1jg5Eg0PgVG1hltqOkcEUjAB6FptDowBkcdjwZDoLDYfjUYQMJikCBoBCMHHDdoUkbU-C07DLFQICQGMiUDS6TU4NTycldcyWHDgNABVBmNzDRyE6azea7XxGDgGno4O6kA5HOBLc45J5uACsaSabI5wHZkE5nG5PD5AkFogeYolSCluBlVI0NJwSvEpDV5AiWuIOtwepU3SN2BNZpQFrgVthBP8uEu9Ua-lq7dKTvglasjyu3tOAFJ-O7B89qp7knAgz3Q5Hw2HnTHefyhCJhcnxqn2qQZGAcXZlarZoXNfhtdhdeTF9BjFweXx41vcKRcpNdO-D8f03mCw1YtS3Le8oyfWMNwTbdxV3DM5QVJVwLXF8BTfSQwFRf9+zddpci2UguwdW4CJnVJqnWTZtlIVt-QaCiNnAaiZjmCgFnokNHxw7A+lCcJIjgaIUDCWxHWQ7h11fIV30+P40BUCVegIMlNWE-jexMQ1emCPjBkE7E1NEuB3mIWTvjgX5-kE8YlPwFS2gGDQNIgyS0Ok0gaEINB5AIRkVy5CTUM3dzPPQHy72AAICBcoLoJkr4FJsnAorsq8HPUmBTU0F0q0opjchots3AAOh9JprNy5S0rUiI2AAX3DLKNDZFKwK4rTkp0xyogMkS4jgZFSAQ44xOXJdV0CuM3MTBAfLGXB5Laibnym4KZoERLKtS1THL8pcIwfA62qO9rXR4rr+KGUZxkmfrJ0DDt9kSWcyttXBqHfFj7Q4rpxi8VR1C0dYCE1UaTuWyCpMTT85jseScqsGtzR+CJ-mOsMTsxjkgA).  As you can see, it just has the `}` but it also doesn't visually display anything.  codemirror does some magic with how it renders the height/width and whether it should add/remove line items.  With jsdom, it would return [offsetWidth](https://github.com/codemirror/CodeMirror/blob/master/src/display/update_display.js#L28) of `""`, and consider the editor hidden.  The problem I had was that it was very confusing understanding where the problem was and the codemirror code base is hard to understand what is happening underneath the hood.

The goal of this PR is to hopefully save someone some time by not having to dig through the `codemirror` code like I did and make react-codemirror2 testable with RTL.

This is a result of the [stub](https://testing-playground.com/#markup=DwEwlgbgfKkAQGMA2BDAzmgvAIgE4FMUEAXAWgQHsR8BbMXXC3AJmxnAkVQxwGEr8AWXqNciGqTSlqAMxQBXJMWxxiuFADs0qYvhwaKbWJzTEAnkj3YKEfLhlIKAdwBccABZgQ1DQG44AA4UaGDEYBQabgQ6kPj+Tl7E7m4AzAEAHv7u+GAA5u7EbgAMGf7EFAHFpXCWMoVwJZlGuunEKAQocKYWVkEhYRFuKABGaBRI8rr+wxTE5TRupACMtP4BKN5gGrlVmXAJIEluS0Wn1dl5BcercHQapBf59Ss0-hSTSFv4bgYacSoKcqUBj4Eg4CgyGQAyYUBAoAKhFCfABeVghUK6AXwSCQCGyCAA1jg5Eg0PgVG1hltqOkcEUjAB6FptDowBkcdjwZDoLDYfjUYQMJikCBoBCMHHDdoUkbU-C07DLFQICQGMiUDS6TU4NTycldcyWHDgNABVBmNzDRyE6azea7XxGDgGno4O6kA5HOBLc45J5uACsjUdbI5wHZkE5nG5PD5AkFogeYolSCluBlVI0NJwSvEpDV5AiWuIOtwepU3SNeEuz2qtVrTSjLqrjyu3tOAFJ-O7Ww34olkg1SoywxHoMYuDy+PGRMLk+NU+1SDIwDi7MrVbNC5r8NrsLr9ZWrL3jtVPYOfY3w2HnTHefyhLPcKRcpNdM+V2v03mCxri6Xy1DSMJzvacBSfSRxQXDM5QVJUm1AuNwKFZ8QlRb8jzddpci2Uh61PPYaGw3CZjmCgFjgZZqhmXBqGfXAaw9Ac3AAFgATmqHs-TbYNblw89UmqdZNm2UgGP9b0hI2cBRNI+0h0I3CTwU7slO4+peK4msHSdeBMOwPpQnCSI4GiFAwlsMoKh0hDuHvGcULwr40BUCVegIMlNXM4zdJMQ1emCIzBlM7FvMsuB3mIT4-h+CJ-lM8Z3PwTy2gGDRfMnWMHwTYUaEINB5AIEdgNvOywMfRy8vQQrySA8dnX0wy0qiUKLLiOBkVIWDjhDa8Sq5MqkIqxMEEKsZcBc2ypyGnLn1GiamArfycHwlTVGstblODNgADINFGAJfD68cxymrKHJGgRXMSnAAg83dUp8mA7vwTLeTgbKIOi17rqrF6Uu8iIjFNTRm16aStlyMTtLgAA6S9HQSv77q8tK2AAb3DEGNDZF7noIN6cA+i7hW+uBfqSgG0ZgbGwduiHRPEtt4eHJHKYewH0qgOByY6EhSF0UxIac4Z1FwMxsDcbAnCYAk0H2UJ3BCoh1QEOgUNYLH1hx8M8eAF7CZUT7HLJinbpRx6gZp7W6YMhmoaZ+oWaaNnzeSjnqYAXy1zRcYIOqA+OwPTonRrAuauARjGCYpg8dTWI4vYBMkvZykqNaaLo0g5PI3YunGLxVHULR1gITVepD0rpuNxNXzmOwXNtk0zRQC04F+drlPY4dg9HPvgNOoA) that I've added.  It renders visually like it would appear to the user ✅.

I've pushed up another [branch to my fork](https://github.com/scniro/react-codemirror2/compare/master...mikedidomizio:react-testing-library?expand=1) that has a test verifying it is working as intended.  Run test with
```node 
npx jest --testNamePattern=^will render JSON beautified with react-testing-library$ --runTestsByPath ./test/index.spec.tsx
```